### PR TITLE
Setup playground for creating server side components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "react"]
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/index.js
+++ b/index.js
@@ -1,3 +1,14 @@
-'use strict';
+import React, { Component } from 'react';
 
-module.exports = 'react-pic';
+export default class Pic extends Component {
+  componentDidMount() {
+  }
+
+  render() {
+    return <img src={this.props.serverImg}></img>;
+  }
+}
+
+Pic.propTypes = {
+  serverImg: React.PropTypes.string.isRequired
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "package",
     "template"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "react": "^15.3.2",
+    "react-dom": "^15.3.2"
+  },
   "devDependencies": {
     "babel-cli": "^6.16.0",
     "babel-core": "^6.17.0",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
   "author": "Ben Budnevich",
   "main": "index.js",
   "scripts": {
+    "dev-server": "webpack-dev-server --config webpack.config.dev.js --progress --colors",
     "test": "mocha",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "server": "nodemon --exec babel-node -- playground/server",
+    "playground": "npm-run-all -p server dev-server"
   },
   "keywords": [
     "npm",
@@ -15,8 +18,18 @@
   ],
   "dependencies": {},
   "devDependencies": {
+    "babel-cli": "^6.16.0",
+    "babel-core": "^6.17.0",
+    "babel-loader": "^6.2.5",
+    "babel-preset-es2015": "^6.16.0",
+    "babel-preset-react": "^6.16.0",
     "eslint": "^3.4.0",
-    "mocha": "^3.0.2"
+    "express": "^4.14.0",
+    "mocha": "^3.0.2",
+    "nodemon": "^1.10.2",
+    "npm-run-all": "^3.1.0",
+    "webpack": "^1.13.2",
+    "webpack-dev-server": "^1.16.1"
   },
   "license": "MIT"
 }

--- a/playground/client.js
+++ b/playground/client.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Component from './index';
+
+ReactDOM.render(
+  React.createElement(
+    Component
+  ), document
+)

--- a/playground/index.js
+++ b/playground/index.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+import Pic from '../index.js';
+
+export default class Playground extends Component {
+  render() {
+    return (
+      <html>
+        <head>
+          <meta charSet='UTF-8' />
+          <title>react-pic</title>
+        </head>
+        <body>
+          <div id="root">
+            <Pic serverImg='//placekitten.com/200/300' />
+          </div>
+          <script src='//localhost:8080/build/react-pic.js' />
+        </body>
+      </html>
+    );
+  }
+}

--- a/playground/server.js
+++ b/playground/server.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import Playground from './index.js';
+import express from 'express'
+import ReactDOMServer = require('react-dom/server');
+
+const app = express();
+const port = 8000;
+
+app.get('/', function(req, resp) {
+ var html = ReactDOMServer.renderToString(
+    React.createElement(Playground)
+  );
+ resp.send(html);
+});
+
+app.listen(port, function() {
+  console.log(`http://localhost:'${port}`);
+})

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,0 +1,25 @@
+import path from 'path';
+import webpack from 'webpack';
+
+module.exports = {
+  entry: [
+    './playground/client' // Your appʼs entry point
+  ],
+  output: {
+    publicPath: 'http://localhost:8080/build/',
+    path: path.join(__dirname, 'build'),
+    filename: './react-pic.js'
+  },
+  module: {
+    loaders: [
+      {
+        test: /.jsx?$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+        query: {
+          presets: ['es2015', 'react']
+        }
+      }
+    ]
+  },
+};


### PR DESCRIPTION
#### Motivation:

When creating components that are supposed to render a certain way on the server side and updated on client side, it is imperative run them universally when developing.
#### Tasks:
- Setup webpack dev server
- Setup universal rendering playground
- Add an .editorconfig file
-  Create a base component
#### Dependencies:
- "react": "^15.3.2"
- "react-dom": "^15.3.2"
#### Dev Dependencies:
- "babel-cli": "^6.16.0"
- "babel-core": "^6.17.0"
- "babel-loader": "^6.2.5"
- "babel-preset-es2015": "^6.16.0"
- "babel-preset-react": "^6.16.0"
- "express": "^4.14.0",
- "nodemon": "^1.10.2",
- "npm-run-all": "^3.1.0"
- "webpack": "^1.13.2",
- "webpack-dev-server": "^1.16.1"
