### PR TITLE
Remove react-addons-shallow-compare

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 import debounce from 'lodash/debounce';
 import get from 'lodash/get';
 import getResponsiveImage from './utils/getResponsiveImage';
@@ -15,10 +14,6 @@ export default class Pic extends Component {
     };
 
     this.setResponsiveImage = this.setResponsiveImage.bind(this);
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidMount() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-pic",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A responsive image loading component.",
   "author": "Ben Budnevich",
   "main": "dist/react-pic.js",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "nodemon": "^1.10.2",
     "npm-run-all": "^3.1.0",
     "react": "^15.3.2",
-    "react-addons-shallow-compare": "^15.3.2",
     "react-addons-test-utils": "^15.3.2",
     "react-dom": "^15.3.2",
     "sinon": "^1.17.6",
@@ -70,7 +69,6 @@
   },
   "peerDependencies": {
     "react": "0.14.x || ^15.0.0-0 || 15.x",
-    "react-addons-shallow-compare": "0.14.x || ^15.0.0-0 || 15.x",
     "react-dom": "0.14.x || ^15.0.0-0 || 15.x"
   },
   "license": "MIT"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,8 +22,7 @@ const config = {
   },
   externals: {
     'react': 'React',
-    'react-dom': 'ReactDOM',
-    'react-addons-shallow-compare': 'var React.addons.shallowCompare'
+    'react-dom': 'ReactDOM'
   }
 };
 


### PR DESCRIPTION
#### Issue:

React addons shallow compare was not properly defined as an external in webpack. To properly define it should look like so: 

```
'react-addons-shallow-compare': {
  root: 'React.addons.shallowCompare',
  commonjs2: 'react-addons-shallow-compare',
  commonjs: 'react-addons-shallow-compare'
}
```

I have elected to remove it for now as the performance gains for react-pic have not been proved necessary. This will require less peer dependencies and make the package easier to install for beginners.
