### PR TITLE
Fix image slot size not being calculated correctly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,9 +24,14 @@ export default class Pic extends Component {
 
   }
 
+  /**
+   * Set the optimal image src
+   */
   setResponsiveImage() {
     try {
-      const imageSlotWidth = this.refs.img.width;
+      const parent = this.refs.base.parentNode;
+      const imageSlotWidth = parent.getBoundingClientRect().width;
+
       const responsiveImage = getResponsiveImage(
         imageSlotWidth,
         this.props.images,
@@ -48,11 +53,12 @@ export default class Pic extends Component {
     }
 
     return (
-      <img
-        alt={alt}
-        ref='img'
-        style={style}
-        src={this.state.image.url} />
+      <div ref='base'>
+        <img
+          alt={alt}
+          style={style}
+          src={this.state.image.url} />
+      </div>
     );
   }
 }

--- a/playground/index.js
+++ b/playground/index.js
@@ -17,24 +17,24 @@ export default class Playground extends Component {
                 alt='heart'
                 images={[
                   {
-                    width: 290,
-                    url: 'http://placehold.it/290?text=♥'
+                    width: 40,
+                    url: 'http://placehold.it/40?text=♥'
                   },
                   {
-                    width: 300,
-                    url: 'http://placehold.it/300?text=♥'
+                    width: 200,
+                    url: 'http://placehold.it/200?text=♥'
                   },
                   {
-                    width: 353,
-                    url: 'http://placehold.it/353?text=♥'
+                    width: 400,
+                    url: 'http://placehold.it/400?text=♥'
                   },
                   {
-                    width: 367,
-                    url: 'http://placehold.it/367?text=♥'
+                    width: 600,
+                    url: 'http://placehold.it/600?text=♥'
                   },
                   {
-                    width: 630,
-                    url: 'http://placehold.it/630?text=♥'
+                    width: 800,
+                    url: 'http://placehold.it/800?text=♥'
                   }
                 ]} />
           </div>

--- a/test/component.js
+++ b/test/component.js
@@ -24,10 +24,9 @@ describe('Pic', function() {
       <Pic { ...props } />
     );
 
-    expect(pic.contains(
+    expect(pic.containsMatchingElement(
       <img
         alt={props.alt}
-        style={pic.props().style}
         src={props.images[0].url} />
     )).to.equal(true);
   });
@@ -52,10 +51,9 @@ describe('Pic', function() {
       <Pic { ...props } />
     );
 
-    expect(pic.contains(
+    expect(pic.containsMatchingElement(
       <img
         alt={props.alt}
-        style={pic.props().style}
         src={props.images[1].url} />
     )).to.equal(true);
   });


### PR DESCRIPTION
Resolves: #19
#### Motivation:

We  use the width of the parent now because the browser takes time to set the width of the image to 100% and doesn't calculate the proper width immediately. The parent is the slot we are trying to fill and therefore will represent the accurate width.
#### Tasks:
- Change width to calculate from parent
- Update playground sizes to be representative of real-world usage
