### PR TITLE
Add noscript image to use high quality image and modify bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ npm install react-pic --save
 
 #### CDN:
 ```html
-<script src='https://unpkg.com/react-pic@0.0.1/dist/react-pic.js'></script>
+<script src='https://unpkg.com/react-pic@0.0.1/dist/umd/react-pic.js'></script>
 
 <!-- or use minified -->
-<script src='https://unpkg.com/react-pic@0.0.1/dist/react-pic.min.js'></script>
+<script src='https://unpkg.com/react-pic@0.0.1/dist/umd/react-pic.min.js'></script>
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ export default class Example extends Component {
 | name         | required | type   | description                                                                                                                |
 |--------------|----------|--------|----------------------------------------------------------------------------------------------------------------------------|
 | images       | true     | Array  | The collection of images you would like to use as a source.                                                                |
-| defaultIndex | false    | Number | The image object to use on initial render.                                                                                 |
+| alt       | false     | string  | Text equivalent of the image. https://www.w3.org/QA/Tips/altAttribute                                                                |
+| defaultIndex | false    | Number | The image object to use on initial render. **Default is 0**                                                                                 |
+| noscriptIndex | false    | Number | The image object to use on noscript render. **Default is last image in images**                                                                                 |
 | style        | false    | Object | Override the style object. **This will remove the default style:** `{ margin: '0 auto', maxWidth: '100%', width: '100%' }` |
 
 ## Testing

--- a/lib/ImageClient.js
+++ b/lib/ImageClient.js
@@ -1,0 +1,14 @@
+import React, { Component } from 'react';
+
+export default class ImageClient extends Component {
+  render() {
+    const { alt, style, image } = this.props;
+
+    return (
+      <img
+        alt={alt}
+        style={style}
+        src={image.url} />
+    );
+  }
+}

--- a/lib/ImageServer.js
+++ b/lib/ImageServer.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react';
+import NoScriptImg from './NoScriptImg';
+
+export default class ImageServer extends Component {
+  render() {
+    const { alt, style, image, noScriptImage } = this.props;
+
+    return (
+      <div>
+        <NoScriptImg
+          alt={alt}
+          image={noScriptImage}
+          style={style} />
+
+        <img
+          alt={alt}
+          style={style}
+          src={image.url} />
+      </div>
+    );
+  }
+}

--- a/lib/NoScriptImg.js
+++ b/lib/NoScriptImg.js
@@ -1,0 +1,26 @@
+import React, { Component } from 'react';
+import ReactDOMServer from 'react-dom/server';
+
+export default class NoScriptImg extends Component {
+  render() {
+    const { alt, style, image} = this.props;
+
+    if(!image) {
+      return null;
+    }
+
+    return (
+      <noscript dangerouslySetInnerHTML={{
+        __html: ReactDOMServer.renderToStaticMarkup(
+          <img
+            alt={alt}
+            style={{
+              ...style,
+              position: 'absolute'
+            }}
+            src={image.url} />
+        )
+      }} />
+    );
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
-import debounce from 'lodash/debounce';
-import get from 'lodash/get';
 import getResponsiveImage from './utils/getResponsiveImage';
+import debounce from './utils/debounce';
+import Image from './ImageServer';
 
 /**
  * Pic Component
@@ -10,7 +10,11 @@ export default class Pic extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      image: get(props.images, props.defaultIndex)
+      image: props.images[props.defaultIndex],
+      noScriptImage: props.noscriptIndex ?
+        props.images[props.noScriptIndex] :
+        props.images[props.images.length-1],
+      isMounted: false
     };
 
     this.setResponsiveImage = this.setResponsiveImage.bind(this);
@@ -19,9 +23,12 @@ export default class Pic extends Component {
   componentDidMount() {
     this.setResponsiveImage();
 
+    this.setState({
+      isMounted: true
+    });
+
     // set responsive image on resize
     window.addEventListener('resize', debounce(this.setResponsiveImage, 150));
-
   }
 
   /**
@@ -46,18 +53,15 @@ export default class Pic extends Component {
   }
 
   render() {
-    const { alt, style } = this.props;
-
     if (!this.state.image) {
       return null;
     }
 
     return (
-      <div ref='base'>
-        <img
-          alt={alt}
-          style={style}
-          src={this.state.image.url} />
+      <div ref='base' style={{
+        position: 'relative'
+      }}>
+        <Image {...this.props} {...this.state} />
       </div>
     );
   }
@@ -103,5 +107,6 @@ Pic.propTypes = {
     }
   },
   defaultIndex: React.PropTypes.number, // The default image to render
+  noscriptIndex: React.PropTypes.number, // The default image to render on noscript
   alt: React.PropTypes.string
 };

--- a/lib/utils/debounce.js
+++ b/lib/utils/debounce.js
@@ -1,0 +1,20 @@
+/**
+ * Trigger last function invoked at end of wait
+ * @callback func                - The function to invoke
+ * @param  {Number} wait         - The ammount of time to wait before invoking
+ * @param  {Boolean} [immediate] - Should the callback be invoked immediately
+ */
+export default function debounce(func, wait, immediate) {
+  let timeout;
+  return function() {
+    const context = this, args = arguments;
+    const later = function() {
+      timeout = null;
+      if (!immediate) func.apply(context, args);
+    };
+    var callNow = immediate && !timeout;
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    if (callNow) func.apply(context, args);
+  };
+}

--- a/lib/utils/getResponsiveImage.js
+++ b/lib/utils/getResponsiveImage.js
@@ -1,4 +1,4 @@
-import reduce from 'lodash/reduce';
+import reduce from 'core-js/library/fn/array/reduce';
 
 /**
  * Get the responsive image.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "react-pic",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A responsive image loading component.",
   "author": "Ben Budnevich",
-  "main": "dist/react-pic.js",
+  "main": "dist/commonjs/react-pic.js",
   "scripts": {
     "build": "npm run build:commonjs && npm run build:umd && npm run build:umd:min",
     "build:commonjs": "cross-env NODE_ENV=development webpack --config webpack.config.commonjs.js dist/commonjs/react-pic.js",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "eslint-plugin-react": "^4.2.3",
     "express": "^4.14.0",
     "istanbul": "^1.0.0-alpha.2",
-    "lodash": "^4.16.3",
     "mocha": "^3.0.2",
     "nodemon": "^1.10.2",
     "npm-run-all": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "author": "Ben Budnevich",
   "main": "dist/react-pic.js",
   "scripts": {
-    "build": "npm run build:umd && npm run build:umd:min",
-    "build:umd": "cross-env NODE_ENV=development webpack lib/index.js dist/react-pic.js",
-    "build:umd:min": "cross-env NODE_ENV=production webpack lib/index.js dist/react-pic.min.js",
+    "build": "npm run build:commonjs && npm run build:umd && npm run build:umd:min",
+    "build:commonjs": "cross-env NODE_ENV=development webpack --config webpack.config.commonjs.js dist/commonjs/react-pic.js",
+    "build:umd": "cross-env NODE_ENV=development webpack --config webpack.config.umd.js dist/umd/react-pic.js",
+    "build:umd:min": "cross-env NODE_ENV=production webpack --config webpack.config.umd.js dist/umd/react-pic.min.js",
     "clean": "npm run clean:coverage && npm run clean:dist",
     "clean:coverage": "rimraf coverage",
     "clean:dist": "rimraf dist",
@@ -48,6 +49,7 @@
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-react": "^6.16.0",
     "chai": "^3.5.0",
+    "core-js": "^2.4.1",
     "coveralls": "^2.11.14",
     "cross-env": "^1.0.7",
     "enzyme": "^2.4.1",
@@ -69,6 +71,9 @@
   "peerDependencies": {
     "react": "0.14.x || ^15.0.0-0 || 15.x",
     "react-dom": "0.14.x || ^15.0.0-0 || 15.x"
+  },
+  "browser": {
+    "./lib/ImageServer.js": "./lib/ImageClient.js"
   },
   "license": "MIT"
 }

--- a/playground/index.js
+++ b/playground/index.js
@@ -14,27 +14,27 @@ export default class Playground extends Component {
         <body>
           <div id="root">
             <Pic
-                alt='heart'
+                alt='winky face'
                 images={[
                   {
                     width: 40,
-                    url: 'http://placehold.it/40?text=♥'
+                    url: 'http://placehold.it/40?text=😉'
                   },
                   {
                     width: 200,
-                    url: 'http://placehold.it/200?text=♥'
+                    url: 'http://placehold.it/200?text=😉'
                   },
                   {
                     width: 400,
-                    url: 'http://placehold.it/400?text=♥'
+                    url: 'http://placehold.it/400?text=😉'
                   },
                   {
                     width: 600,
-                    url: 'http://placehold.it/600?text=♥'
+                    url: 'http://placehold.it/600?text=😉'
                   },
                   {
                     width: 800,
-                    url: 'http://placehold.it/800?text=♥'
+                    url: 'http://placehold.it/800?text=😉'
                   }
                 ]} />
           </div>

--- a/test/component.js
+++ b/test/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { shallow, mount } from 'enzyme';
+import { shallow, mount, render } from 'enzyme';
 import Pic from '../lib/';
 import { spy } from 'sinon';
 
@@ -20,7 +20,7 @@ describe('Pic', function() {
       ]
     };
 
-    const pic = shallow(
+    const pic = mount(
       <Pic { ...props } />
     );
 
@@ -47,7 +47,7 @@ describe('Pic', function() {
       ]
     };
 
-    const pic = shallow(
+    const pic = mount(
       <Pic { ...props } />
     );
 
@@ -56,6 +56,29 @@ describe('Pic', function() {
         alt={props.alt}
         src={props.images[1].url} />
     )).to.equal(true);
+  });
+
+  it('should render the last image in noscript', function() {
+    const props = {
+      alt: 'heart',
+      images: [
+        {
+          width: 290,
+          url: 'http://placehold.it/290?text=♥'
+        },
+        {
+          width: 320,
+          url: 'http://placehold.it/320?text=♥'
+        }
+      ]
+    };
+
+    const pic = render(
+      <Pic { ...props } />
+    );
+
+    expect(pic.find('noscript img').length).to.equal(1);
+    expect(pic.find('noscript img').attr('src')).to.equal(props.images[1].url);
   });
 
   it('should not render image if props are not passed', function() {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,33 +1,57 @@
 import { expect } from 'chai';
 import getResponsiveImage from '../lib/utils/getResponsiveImage';
+import debounce from '../lib/utils/debounce';
 
 describe('Utils', function() {
-  const images= [
-    {
-      width: 40,
-      url: 'http://placehold.it/40?text=♥'
-    },
-    {
-      width: 290,
-      url: 'http://placehold.it/290?text=♥'
-    },
-    {
-      width: 320,
-      url: 'http://placehold.it/320?text=♥'
-    }
-  ];
+  describe('getResponsiveImage', function() {
+    const images= [
+      {
+        width: 40,
+        url: 'http://placehold.it/40?text=♥'
+      },
+      {
+        width: 290,
+        url: 'http://placehold.it/290?text=♥'
+      },
+      {
+        width: 320,
+        url: 'http://placehold.it/320?text=♥'
+      }
+    ];
 
-  it('should select the correct image in images', function() {
-    expect(getResponsiveImage('40', images, images[0])).to.equal(images[0]);
-    expect(getResponsiveImage('290', images, images[0])).to.equal(images[1]);
-    expect(getResponsiveImage('200', images, images[0])).to.equal(images[1]);
-    expect(getResponsiveImage('320', images, images[0])).to.equal(images[2]);
-    expect(getResponsiveImage('40', images, images[2])).to.equal(images[2]);
+    it('should select the correct image in images', function() {
+      expect(getResponsiveImage('40', images, images[0])).to.equal(images[0]);
+      expect(getResponsiveImage('290', images, images[0])).to.equal(images[1]);
+      expect(getResponsiveImage('200', images, images[0])).to.equal(images[1]);
+      expect(getResponsiveImage('320', images, images[0])).to.equal(images[2]);
+      expect(getResponsiveImage('40', images, images[2])).to.equal(images[2]);
+    });
+
+    it(`should never select a smaller image than one that is
+        already loaded`, function() {
+      expect(getResponsiveImage('40', images, images[2])).to.equal(images[2]);
+      expect(getResponsiveImage('290', images, images[2])).to.equal(images[2]);
+    });
   });
 
-  it(`should never select a smaller image than one that is
-      already loaded`, function() {
-    expect(getResponsiveImage('40', images, images[2])).to.equal(images[2]);
-    expect(getResponsiveImage('290', images, images[2])).to.equal(images[2]);
+  describe('debounce', function() {
+    it('debounces correctly', function(done) {
+      let counter = 0;
+
+      const increment = function () {
+        return counter++;
+      };
+
+      let debouncedIncr = debounce(increment, 15);
+
+      debouncedIncr();
+      debouncedIncr();
+
+      setTimeout(function() {
+        expect(counter).to.equal(1);
+        done();
+      }, 100);
+
+    });
   });
 });

--- a/webpack.config.commonjs.js
+++ b/webpack.config.commonjs.js
@@ -2,11 +2,16 @@ const webpack = require('webpack');
 const env = process.env.NODE_ENV;
 
 const config = {
+  entry: [
+    'babel-polyfill',
+    './lib/index.js'
+  ],
   devtool: 'source-map',
   output: {
-    libraryTarget: 'umd',
+    libraryTarget: 'commonjs',
     library: 'Pic'
   },
+  target: 'node',
   plugins: [],
   module: {
     loaders: [
@@ -21,18 +26,8 @@ const config = {
     ]
   },
   externals: {
-    'react': {
-      root: 'React',
-      amd: 'react',
-      commonjs2: 'react',
-      commonjs: 'react'
-    },
-    'react-dom': {
-      root: 'ReactDOM',
-      amd: 'react-dom',
-      commonjs2: 'react-dom',
-      commonjs: 'react-dom'
-    }
+    'react': 'react',
+    'react-dom/server': 'react-dom/server'
   }
 };
 

--- a/webpack.config.umd.js
+++ b/webpack.config.umd.js
@@ -1,0 +1,45 @@
+const webpack = require('webpack');
+const env = process.env.NODE_ENV;
+
+const config = {
+  entry: [
+    './lib/index.js'
+  ],
+  output: {
+    libraryTarget: 'umd',
+    library: 'Pic'
+  },
+  plugins: [],
+  module: {
+    loaders: [
+      {
+        test: /.jsx?$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+        query: {
+          presets: ['es2015', 'react']
+        }
+      }
+    ]
+  },
+  externals: {
+    'react': {
+      root: 'React',
+      amd: 'react',
+      commonjs2: 'react',
+      commonjs: 'react'
+    }
+  }
+};
+
+if (env === 'production') {
+  config.plugins.push(
+    new webpack.optimize.UglifyJsPlugin({
+      compressor: {
+        warnings: false
+      }
+    })
+  );
+}
+
+module.exports = config;


### PR DESCRIPTION
Resolves: #18 
#### Motivation:

When bots crawl, or users with javascript disabled visit a site that uses server side rendering and `react-pic` it would display a low quality version of the image. With this update, it will select the presumable highest quality image ( or image of your choosing ) for the noscript image on server-side.

If using this only on the client-side this will not affect how this package works.

In addition, lodash has been stripped because it was causing bundle size to be increased dramatically.
#### Tasks:
- Create a debounce util
- Use core-js reduce instead of lodash/reduce
- Remove lodash and replace with simple js and utils
- Add ability to specify which image to render on noscript
- Create seperate umd and commonjs bundle
- Update readme to include additional props `alt` and `noscriptIndex`
