### PR TITLE
Update package.json and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://travis-ci.org/benox3/react-pic.svg?branch=master)](https://travis-ci.org/benox3/react-pic)
 [![Coverage Status](https://coveralls.io/repos/github/benox3/react-pic/badge.svg?branch=master)](https://coveralls.io/github/benox3/react-pic?branch=master)
 
-A responsive image loading component.
+React component for progressive and responsive image loading.
 
 react-pic works universally. On the server-side, it works by setting a default image (usually something very small to reduce data). On the client-side, it will try to load the optimal image based on [prop data](#Props).
 

--- a/README.md
+++ b/README.md
@@ -58,12 +58,6 @@ export default class Example extends Component {
 | noscriptIndex | false    | Number | The image object to use on noscript render. **Default is last image in images**                                                                                 |
 | style        | false    | Object | Override the style object. **This will remove the default style:** `{ margin: '0 auto', maxWidth: '100%', width: '100%' }` |
 
-## Testing
-
-```sh
-$ npm test
-```
-
 ## Special Thanks
 
 - To [remarkablemark](https://github.com/remarkablemark) and [tdlm](https://github.com/tdlm) for their feedback and review.

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ npm install react-pic --save
 
 #### CDN:
 ```html
-<script src='https://unpkg.com/react-pic@0.0.1/dist/umd/react-pic.js'></script>
+<script src='https://unpkg.com/react-pic@latest/dist/umd/react-pic.js'></script>
 
 <!-- or use minified -->
-<script src='https://unpkg.com/react-pic@0.0.1/dist/umd/react-pic.min.js'></script>
+<script src='https://unpkg.com/react-pic@latest/dist/umd/react-pic.min.js'></script>
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-pic",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "React component for progressive and responsive image loading.",
   "author": "Ben Budnevich",
   "main": "dist/commonjs/react-pic.js",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "img",
     "progressive",
     "loading",
-    "responsive"
+    "responsive",
+    "universal"
   ],
   "bugs": {
     "url": "https://github.com/benox3/react-pic/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-pic",
   "version": "0.0.7",
-  "description": "A responsive image loading component.",
+  "description": "React component for progressive and responsive image loading.",
   "author": "Ben Budnevich",
   "main": "dist/commonjs/react-pic.js",
   "scripts": {

--- a/webpack.config.commonjs.js
+++ b/webpack.config.commonjs.js
@@ -3,7 +3,6 @@ const env = process.env.NODE_ENV;
 
 const config = {
   entry: [
-    'babel-polyfill',
     './lib/index.js'
   ],
   devtool: 'source-map',

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,14 +1,23 @@
 const path = require('path');
+const webpack = require('webpack');
 
 module.exports = {
   entry: [
     './playground/client' // Your appʼs entry point
   ],
+  target: 'node',
   output: {
     publicPath: 'http://localhost:8080/build/',
     path: path.join(__dirname, 'build'),
     filename: './react-pic.js'
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify('development')
+      }
+    })
+  ],
   module: {
     loaders: [
       {


### PR DESCRIPTION
#### Tasks:
- Update CDN src to point to latest in README
- Update package.description
- Add 'universal' keyword to `package.json`
- Remove unnecessary `babel-polyfill` from `commonjs` build
- Fix playground script by ensuring webpack-dev-server target is `node`
