### PR TITLE
Move react-addons-shallow-compare to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-pic",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "React component for progressive and responsive image loading.",
   "author": "Ben Budnevich",
   "main": "dist/commonjs/react-pic.js",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,6 @@
   "bugs": {
     "url": "https://github.com/benox3/react-pic/issues"
   },
-  "dependencies": {
-    "react-addons-shallow-compare": "0.14.x || ^15.0.0-0 || 15.x"
-  },
   "devDependencies": {
     "babel-cli": "^6.16.0",
     "babel-core": "^6.17.0",
@@ -74,7 +71,8 @@
   },
   "peerDependencies": {
     "react": "0.14.x || ^15.0.0-0 || 15.x",
-    "react-dom": "0.14.x || ^15.0.0-0 || 15.x"
+    "react-dom": "0.14.x || ^15.0.0-0 || 15.x",
+    "react-addons-shallow-compare": "0.14.x || ^15.0.0-0 || 15.x"
   },
   "browser": {
     "./lib/server/index.js": "./lib/client/index.js"

--- a/webpack.config.commonjs.js
+++ b/webpack.config.commonjs.js
@@ -26,7 +26,8 @@ const config = {
   },
   externals: {
     'react': 'react',
-    'react-dom/server': 'react-dom/server'
+    'react-dom/server': 'react-dom/server',
+    'react-addons-shallow-compare': 'react-addons-shallow-compare'
   }
 };
 

--- a/webpack.config.umd.js
+++ b/webpack.config.umd.js
@@ -28,6 +28,12 @@ const config = {
       amd: 'react',
       commonjs2: 'react',
       commonjs: 'react'
+    },
+    'react-addons-shallow-compare': {
+      root: 'React.addons.shallowCompare',
+      amd: 'react-addons-shallow-compare',
+      commonjs2: 'react-addons-shallow-compare',
+      commonjs: 'react-addons-shallow-compare'
     }
   }
 };


### PR DESCRIPTION
#### Tasks:
- Create externals for commonjs and umd builds for `react-addons-shallow-compare`
- Move  `react-addons-shallow-compare` to `peerDependencies`
