### PR TITLE
Update NoScriptImg to no longer rely on `react-dom/server`

### DIFF
--- a/lib/server/NoScriptImg.js
+++ b/lib/server/NoScriptImg.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import ReactDOMServer from 'react-dom/server';
+import convertReactToHTMLStyle from '../utils/convertReactToHTMLStyle';
 
 export default class NoScriptImg extends Component {
   render() {
@@ -11,15 +11,12 @@ export default class NoScriptImg extends Component {
 
     return (
       <noscript dangerouslySetInnerHTML={{
-        __html: ReactDOMServer.renderToStaticMarkup(
+        __html: `
           <img
-            alt={alt}
-            style={{
-              ...style,
-              position: 'absolute'
-            }}
-            src={image.url} />
-        )
+            alt='${alt}'
+            style='${convertReactToHTMLStyle(style)}'
+            src='${image.url}' />
+        `
       }} />
     );
   }

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -11,7 +11,7 @@ export default class ImageBase extends Component {
   render() {
     const {
       alt,
-      style,
+      imgStyle,
       noScriptImage
     } = this.props;
 
@@ -20,7 +20,11 @@ export default class ImageBase extends Component {
         <NoScriptImg
           alt={alt}
           image={noScriptImage}
-          style={style} />
+          style={{
+            ...imgStyle,
+            position: 'absolute',
+            zIndex: imgStyle.zIndex ? imgStyle.zIndex + 1 : 10
+          }} />
 
         <Image {...this.props} />
       </div>

--- a/lib/utils/convertReactToHTMLStyle.js
+++ b/lib/utils/convertReactToHTMLStyle.js
@@ -1,0 +1,12 @@
+export default function convertReactToHTMLStyle(style) {
+  let styleString = '';
+  for (let i in style) {
+    styleString += i.replace(
+      /(ms[A-Z])/g, '-$1'
+    ).replace(
+      /([A-Z])/g, '-$1'
+    ).toLowerCase();
+    styleString += `:${style[i]};`;
+  }
+  return styleString;
+}

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
   },
   "peerDependencies": {
     "react": "0.14.x || ^15.0.0-0 || 15.x",
-    "react-dom": "0.14.x || ^15.0.0-0 || 15.x",
     "react-addons-shallow-compare": "0.14.x || ^15.0.0-0 || 15.x"
   },
   "browser": {

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,9 +2,10 @@ import { expect } from 'chai';
 import getResponsiveImage from '../lib/utils/getResponsiveImage';
 import debounce from '../lib/utils/debounce';
 import isElementInView from '../lib/utils/isElementInView';
+import convertReactToHTMLStyle from '../lib/utils/convertReactToHTMLStyle';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { mount } from 'enzyme';
+import { mount, render } from 'enzyme';
 
 describe('Utils', function() {
   describe('getResponsiveImage', function() {
@@ -102,6 +103,70 @@ describe('Utils', function() {
       };
 
       expect(isElementInView(ReactDOM.findDOMNode(wrapper.instance()))).to.equal(false);
+    });
+  });
+
+  describe('convertReactToHTMLStyle', function() {
+    it('converts vendor prefixes correctly', function() {
+      const style = {
+        WebkitTransition: 'all',
+        msTransition: 'all',
+        MozTransition: 'all',
+        OTransition: 'all'
+      };
+      const wrapper = render(
+        <div style={style}></div>
+      );
+
+      expect(
+        convertReactToHTMLStyle(style)
+      ).to.equal(
+        wrapper.find('div').attr('style')
+      );
+    });
+
+    it('converts single style correctly', function() {
+      const style = {
+        display: 'none'
+      };
+      const wrapper = render(
+        <div style={style}></div>
+      );
+
+      expect(
+        convertReactToHTMLStyle(style)
+      ).to.equal(
+        wrapper.find('div').attr('style')
+      );
+    });
+
+    it('converts multiple styles correctly', function() {
+      const style = {
+        display: 'none',
+        visibility: 'hidden'
+      };
+      const wrapper = render(
+        <div style={style}></div>
+      );
+
+      expect(
+        convertReactToHTMLStyle(style)
+      ).to.equal(
+        wrapper.find('div').attr('style')
+      );
+    });
+
+    it('converts empty style correctly', function() {
+      const style = {};
+      const wrapper = render(
+        <div style={style}></div>
+      );
+
+      expect(
+        convertReactToHTMLStyle(style)
+      ).to.equal(
+        wrapper.find('div').attr('style') || ''
+      );
     });
   });
 });

--- a/webpack.config.commonjs.js
+++ b/webpack.config.commonjs.js
@@ -25,9 +25,7 @@ const config = {
     ]
   },
   externals: {
-    'react': 'react',
-    'react-dom/server': 'react-dom/server',
-    'react-addons-shallow-compare': 'react-addons-shallow-compare'
+    'react': 'react'
   }
 };
 


### PR DESCRIPTION
#### Motivation:

ReactDOMServer.renderToStaticMarkup was being used in order to render an element inside of `<noscript />` without causing invariant error. Unfortunately, this was causing `react-dom/server` to be a required peer dependency and would often be bundled in with dependencies causing bundles to be much larger than needed. Due to the nature of `<noscript />` we can safely set the inner elements using dangerouslySetInnerHTML. The one caveat is that we needed a utility to convert react style objects to a html style string.
#### Tasks:
- Use convertReactToHTMLStyle utility to convert react style to string
- Remove react-dom/server from externals and react-dom from peer
  dependencies
