### PR TITLE
Fix UMD build by changing external declaration of shallowCompare

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,3 @@
 import Pic from './common/Pic';
 
-export default Pic;
+module.exports = Pic;

--- a/webpack.config.umd.js
+++ b/webpack.config.umd.js
@@ -30,7 +30,7 @@ const config = {
       commonjs: 'react'
     },
     'react-addons-shallow-compare': {
-      root: 'React.addons.shallowCompare',
+      root: ['React', 'addons', 'shallowCompare'],
       amd: 'react-addons-shallow-compare',
       commonjs2: 'react-addons-shallow-compare',
       commonjs: 'react-addons-shallow-compare'


### PR DESCRIPTION
#### Tasks:
- Update external definition for `react-addons-shallow-compare` so that it no longer throws an exception
- Use module.exports instead of export default for our base component so that on UMD the component can be defined as Pic instead of Pic.default
