### PR TITLE
Remove whitespace caused by template string

### DIFF
--- a/lib/server/NoScriptImg.js
+++ b/lib/server/NoScriptImg.js
@@ -11,12 +11,11 @@ export default class NoScriptImg extends Component {
 
     return (
       <noscript dangerouslySetInnerHTML={{
-        __html: `
-          <img
-            alt='${alt}'
-            style='${convertReactToHTMLStyle(style)}'
-            src='${image.url}' />
-        `
+        __html:
+          '<img ' +
+            `alt='${alt}' ` +
+            `style='${convertReactToHTMLStyle(style)}' ` +
+            `src='${image.url}' />`
       }} />
     );
   }


### PR DESCRIPTION
Resolves #34
#### Issue:
- Template strings were creating additional whitespace which results in uglier html and larger payload when sending data from the server
#### Tasks:
- Remove whitespace caused by template string
