### PR TITLE
Fix `getResponsiveImage` util logic and tests

### DIFF
--- a/lib/utils/getResponsiveImage.js
+++ b/lib/utils/getResponsiveImage.js
@@ -11,15 +11,6 @@ import reduce from 'core-js/library/fn/array/reduce';
  */
 export default function getResponsiveImage(imageSlotWidth, images, currentImg) {
   return reduce(images, (prev, cur) => {
-
-    if (prev && prev.width === imageSlotWidth) {
-      return prev;
-    }
-
-    if (cur.width === imageSlotWidth) {
-      return cur;
-    }
-
     if (prev.width < imageSlotWidth) {
       return cur;
     } else {

--- a/test/utils.js
+++ b/test/utils.js
@@ -25,17 +25,16 @@ describe('Utils', function() {
     ];
 
     it('should select the correct image in images', function() {
-      expect(getResponsiveImage('40', images, images[0])).to.equal(images[0]);
-      expect(getResponsiveImage('290', images, images[0])).to.equal(images[1]);
-      expect(getResponsiveImage('200', images, images[0])).to.equal(images[1]);
-      expect(getResponsiveImage('320', images, images[0])).to.equal(images[2]);
-      expect(getResponsiveImage('40', images, images[2])).to.equal(images[2]);
+      expect(getResponsiveImage(40, images, images[0])).to.equal(images[0]);
+      expect(getResponsiveImage(290, images, images[0])).to.equal(images[1]);
+      expect(getResponsiveImage(200, images, images[0])).to.equal(images[1]);
+      expect(getResponsiveImage(320, images, images[0])).to.equal(images[2]);
     });
 
     it(`should never select a smaller image than one that is
         already loaded`, function() {
-      expect(getResponsiveImage('40', images, images[2])).to.equal(images[2]);
-      expect(getResponsiveImage('290', images, images[2])).to.equal(images[2]);
+      expect(getResponsiveImage(40, images, images[2])).to.equal(images[2]);
+      expect(getResponsiveImage(290, images, images[2])).to.equal(images[2]);
     });
   });
 


### PR DESCRIPTION
#### Tasks:
- Fix logic in getResponsiveImage, it was returning an incorrect value if a larger image was passed through
- Update tests to catch everything properly by passing through integers and not strings for slot width
